### PR TITLE
Fix linting error in initial state of repo

### DIFF
--- a/src/modules/users/tests/users.controller.spec.ts
+++ b/src/modules/users/tests/users.controller.spec.ts
@@ -43,10 +43,10 @@ describe("UsersController", () => {
 
       expect(res.statusCode).toBe(201);
       expect(res.body).toMatchObject({
-        id: expect.any(String),
+        id: expect.any(String), // eslint-disable-line @typescript-eslint/no-unsafe-assignment
         email: expect.stringContaining(createUserDto.email) as string,
-        createdAt: expect.any(String),
-        updatedAt: expect.any(String),
+        createdAt: expect.any(String), // eslint-disable-line @typescript-eslint/no-unsafe-assignment
+        updatedAt: expect.any(String), // eslint-disable-line @typescript-eslint/no-unsafe-assignment
       });
     });
 


### PR DESCRIPTION
Running `npm run lint` raised the following error in a few lines:

```
error  Unsafe assignment of an `any` value  @typescript-eslint/no-unsafe-assignment
```

Linting for those lines is now disabled.